### PR TITLE
fix: Quarto Extension Attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Contributions of any kind welcome, just follow the [guidelines](.github/CONTRIBU
 
 - [Tutorial: Creating your personal website using Quarto](https://ucsb-meds.github.io/creating-quarto-websites/) - A step-by-step guide for setting up a personal website using Quarto by Samantha Csik.
 - [A beginner's guide to using Observable JavaScript, R, and Python with Quarto](https://www.infoworld.com/article/3674789/a-beginners-guide-to-using-observable-javascript-r-and-python-with-quarto.html) - This article shows you how to set up a Quarto document to use Observable JavaScript, including how to pass data from R or Python to an Observable code chunk.
+- [attribution](https://github.com/quarto-ext/attribution) - A Quarto extension that brings Reveal.js plugin for displaying attribution text sideways along the right edge of the viewport.
 
 <!--lint enable awesome-list-item-->
 <!--lint enable double-link-->
@@ -155,6 +156,7 @@ Contributions of any kind welcome, just follow the [guidelines](.github/CONTRIBU
 - [elevator](https://github.com/mcanouil/quarto-elevator) - This extension provides support and shortcode to Elevator.js.
 - [code-visibility](https://github.com/jjallaire/code-visibility) - This extension implements some directives for filtering code and stream output included within a document.
 - [roughnotation](https://github.com/EmilHvitfeldt/quarto-roughnotation) - An extension that uses the [roughnotation](https://roughnotation.com/) JavaScript library to add animated annotations to `revealjs` documents.
+- [attribution](https://github.com/quarto-ext/attribution) - A Quarto extension that brings Reveal.js plugin for displaying attribution text sideways along the right edge of the viewport.
 
 ## Templates
 


### PR DESCRIPTION
## What does this PR do?

- [attribution](https://github.com/quarto-ext/attribution) - A Quarto extension that brings Reveal.js plugin for displaying attribution text sideways along the right edge of the viewport.  
  Fixes #135

## Requirements for your Awesome item list

- [x] Only has awesome items. Awesome lists are curations of the best, not everything.
- [x] Does not contain items that are unmaintained, has archived repo, deprecated, or missing docs. If you really need to include such items, they should be in a separate Markdown file.
- [x] Entries have a description, unless the title is descriptive enough by itself. It rarely is though.
- [x] Has consistent formatting and proper spelling/grammar.
      - The link and description are separated by a dash.  
        Example: `- [AVA](…) - JavaScript test runner.`
      - The description starts with an uppercase character and ends with a period.
      - Consistent and correct naming. For example, `Node.js`, not `NodeJS` or `node.js`.
- [x] Doesn't use [hard-wrapping](https://stackoverflow.com/questions/319925/difference-between-hard-wrap-and-soft-wrap).
- [x] Your item(s) fit into an existing sections. (if you think a new section is needed, please [open a discussion](https://github.com/mcanouil/awesome-quarto/discussions/new?category=ideas) first).
- [x] Add your new item to the bottom of the list in a section.
- [x] If a duplicate item exists, discuss why the new item should replace it.
- [x] Check your spelling & grammar.
- [x] The item must follow this format:
  ```
  - [item name](https link) - Description beginning with capital, ending in period.
  ```
- [x] Be sure to have read the [contributing guidelines](CONTRIBUTING.md).
