### PR TITLE
fix: Pointer Quarto extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Contributions of any kind welcome, just follow the [guidelines](.github/CONTRIBU
 - [A beginner's guide to using Observable JavaScript, R, and Python with Quarto](https://www.infoworld.com/article/3674789/a-beginners-guide-to-using-observable-javascript-r-and-python-with-quarto.html) - This article shows you how to set up a Quarto document to use Observable JavaScript, including how to pass data from R or Python to an Observable code chunk.
 - [attribution](https://github.com/quarto-ext/attribution) - A Quarto extension that brings Reveal.js plugin for displaying attribution text sideways along the right edge of the viewport.
 - [shinylive](https://github.com/quarto-ext/shinylive) - This extension lets you embed [Shinylive](https://shiny.rstudio.com/py/docs/shinylive.html) ([Shiny for Python](https://shiny.rstudio.com/py/)) applications in a Quarto document.
+- [pointer](https://github.com/quarto-ext/pointer) - A Quarto extension that brings a very simple Reveal.js plugin that adds support for switching the cursor to a 'pointer' style element while presenting.
 
 <!--lint enable awesome-list-item-->
 <!--lint enable double-link-->
@@ -159,6 +160,7 @@ Contributions of any kind welcome, just follow the [guidelines](.github/CONTRIBU
 - [roughnotation](https://github.com/EmilHvitfeldt/quarto-roughnotation) - An extension that uses the [roughnotation](https://roughnotation.com/) JavaScript library to add animated annotations to `revealjs` documents.
 - [attribution](https://github.com/quarto-ext/attribution) - A Quarto extension that brings Reveal.js plugin for displaying attribution text sideways along the right edge of the viewport.
 - [shinylive](https://github.com/quarto-ext/shinylive) - This extension lets you embed [Shinylive](https://shiny.rstudio.com/py/docs/shinylive.html) ([Shiny for Python](https://shiny.rstudio.com/py/)) applications in a Quarto document.
+- [pointer](https://github.com/quarto-ext/pointer) - A Quarto extension that brings a very simple Reveal.js plugin that adds support for switching the cursor to a 'pointer' style element while presenting.
 
 ## Templates
 


### PR DESCRIPTION
## What does this PR do?

- [pointer](https://github.com/quarto-ext/pointer) - A Quarto extension that brings a very simple Reveal.js plugin that adds support for switching the cursor to a 'pointer' style element while presenting.  
  Fixes #141

## Requirements for your Awesome item list

- [x] Only has awesome items. Awesome lists are curations of the best, not everything.
- [x] Does not contain items that are unmaintained, has archived repo, deprecated, or missing docs. If you really need to include such items, they should be in a separate Markdown file.
- [x] Entries have a description, unless the title is descriptive enough by itself. It rarely is though.
- [x] Has consistent formatting and proper spelling/grammar.
      - The link and description are separated by a dash.  
        Example: `- [AVA](…) - JavaScript test runner.`
      - The description starts with an uppercase character and ends with a period.
      - Consistent and correct naming. For example, `Node.js`, not `NodeJS` or `node.js`.
- [x] Doesn't use [hard-wrapping](https://stackoverflow.com/questions/319925/difference-between-hard-wrap-and-soft-wrap).
- [x] Your item(s) fit into an existing sections. (if you think a new section is needed, please [open a discussion](https://github.com/mcanouil/awesome-quarto/discussions/new?category=ideas) first).
- [x] Add your new item to the bottom of the list in a section.
- [x] If a duplicate item exists, discuss why the new item should replace it.
- [x] Check your spelling & grammar.
- [x] The item must follow this format:
  ```
  - [item name](https link) - Description beginning with capital, ending in period.
  ```
- [x] Be sure to have read the [contributing guidelines](CONTRIBUTING.md).
