### PR TITLE
fix: 'seasons' Quarto Reveal.js template

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Contributions of any kind welcome, just follow the [guidelines](.github/CONTRIBU
 - [metropolis-theme](https://codeberg.org/pat-s/quarto-metropolis) - Opinionated port of the Metropolis template for Quarto `revealjs` presentation.
 - [letterbox](https://github.com/EmilHvitfeldt/quarto-revealjs-letterbox) - A Quarto extension for authoring letterbox styled presentations using `revealjs` formats.
 - [quarto-revealjs-inverse](https://github.com/EmilHvitfeldt/quarto-revealjs-inverse) - The goal of this repository is to provide an example of how to create a inverse class to use in `revealjs` slides.
+- [quarto-revealjs-seasons](https://github.com/EmilHvitfeldt/quarto-revealjs-seasons) - The is an example of how to create a `revealjs` theme with multiple styles.
 
 ### HTML Documents
 


### PR DESCRIPTION
- [quarto-revealjs-seasons](https://github.com/EmilHvitfeldt/quarto-revealjs-seasons) - The is an example of how to create a `revealjs` theme with multiple styles.  
  Fixes #254

co-authored-by: Emil Hvitfeldt <EmilHvitfeldt@users.noreply.github.com>