### PR TITLE
fix: Extensions about line highlighting the source code and code output for HTML format

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Contributions of any kind welcome, just follow the [guidelines](.github/CONTRIBU
 - [multibib](https://github.com/pandoc-ext/multibib) - This extension provides support for multiple bibliographies.
 - [stata-facade](https://github.com/CenterOnBudget/quarto-stata-facade) - A Quarto extension that hides the evidence of faking Stata dynamic content with Python code blocks and [Stata cell magic](https://www.stata.com/python/pystata/notebook/Magic%20Commands1.html).
 - [authors-block](https://github.com/kapsner/authors-block) - This extension brings the capability to add an author-related header block when rendering `docx` documents with Quarto.
+- [line-highlight](https://github.com/shafayetShafee/line-highlight) - Quarto Extension to implement source code line highlighting and output line highlighting for `html` documents.
 
 ## Templates
 


### PR DESCRIPTION
## What does this PR do?

- [line-highlight](https://github.com/shafayetShafee/line-highlight) - Quarto Extension to implement source code line highlighting and output line highlighting for `html` documents.  
  Fixes #256

co-authored-by: Shafayet khan Shafee <shafayetShafee@users.noreply.github.com>
