### PR TITLE
fix: hedgedoc-slides Quarto filter extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Contributions of any kind welcome, just follow the [guidelines](.github/CONTRIBU
 - [stata-facade](https://github.com/CenterOnBudget/quarto-stata-facade) - A Quarto extension that hides the evidence of faking Stata dynamic content with Python code blocks and [Stata cell magic](https://www.stata.com/python/pystata/notebook/Magic%20Commands1.html).
 - [authors-block](https://github.com/kapsner/authors-block) - This extension brings the capability to add an author-related header block when rendering `docx` documents with Quarto.
 - [line-highlight](https://github.com/shafayetShafee/line-highlight) - Quarto Extension to implement source code line highlighting and output line highlighting for `html` documents.
+- [hedgedoc-slides](https://github.com/sokotim/hedgedoc-slides) - A LUA filter to convert `revealjs` presentations to [HedgeDoc](https://hedgedoc.org/) presentations.
 
 ## Templates
 


### PR DESCRIPTION
## What does this PR do?

- [hedgedoc-slides](https://github.com/sokotim/hedgedoc-slides) - A LUA filter to convert `revealjs` presentations to [HedgeDoc](https://hedgedoc.org/) presentations.  
  Fixes #258

co-authored-by: Tim Sokollek <sokotim@users.noreply.github.com>
