### PR TITLE
feat: add Quarto Pressmark theme to website formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Contributions of any kind are welcome, just follow the [guidelines](.github/CONT
 - [Juan Torres Munguía's website](https://github.com/jatorresmunguia/juan-torresmunguia.github.io) - A Quarto website with a custom theme adapted from flatly, integrating particles.js for a lightweight, interactive canvas background on the home page (see <https://juan-torresmunguia.netlify.app/>).
 - [DES RAP Book](https://pythonhealthdatascience.github.io/des_rap_book/) - A self-paced training resource on developing discrete event simulation models in Python and R, with a toggle at the top of each page allowing readers to switch between languages.
 - [Noah Weidig's website](https://github.com/noahweidig/noahweidig.github.io) - A single-page portfolio and blog with a custom light/dark theme (based on cosmo), an interactive 3D globe, and post-render scripts generating Open Graph cards.
+- [Quarto Pressmark](https://mdwm.org/quarto-pressmark/) - An elegant, typographic, minimalistic theme for Quarto websites, inspired by newspapers and tufte-css, with curated fonts and extensive custom styling (see <https://github.com/skriptum/quarto-pressmark>).
 
 ### Book formats
 


### PR DESCRIPTION
Adds Quarto Pressmark to the Websites formats section of the real-life examples.

Pressmark is a typographic, minimalistic theme for Quarto websites, distributed as an SCSS file rather than a Quarto extension, so it does not belong in the extensions listing. The linked documentation site is itself built with the theme.

Fixes #438