### PR TITLE
chore: bump CITATION.cff to 2026.07.27

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,5 +9,5 @@ authors:
 repository-code: "https://github.com/mcanouil/awesome-quarto"
 url: "http://m.canouil.dev/awesome-quarto/"
 license: "CC0 1.0 Universal (CC0-1.0) Public Domain Dedication"
-date-released: "2026-02-26"
-version: 2026.02.26
+date-released: "2026-07-27"
+version: 2026.07.27


### PR DESCRIPTION
Synchronise `CITATION.cff` with the upcoming `2026.07.27` release.

The file was last updated for `2026.02.26` and was not bumped for `2026.06.01`.