### PR TITLE
fix: repair outdated links and fail CI on redirects

### DIFF
--- a/.github/workflows/awesome-bot.yml
+++ b/.github/workflows/awesome-bot.yml
@@ -29,4 +29,4 @@ jobs:
       - name: "install awesome-bot"
         run: gem install awesome_bot
       - name: "linting: README.md"
-        run: awesome_bot --allow-redirect --allow-dupe --white-list quarto.org,https://github.com/quarto-dev,https://www.gnu.org/software/emacs/,https://rfortherestofus.com/,https://drmowinckels.io/ README.md
+        run: awesome_bot --allow-dupe --white-list quarto.org,https://github.com/quarto-dev,https://www.gnu.org/software/emacs/,https://rfortherestofus.com/,https://drmowinckels.io/,https://awesome.re,https://github.com/mcanouil/awesome-quarto/issues/new,https://www.youtube.com/playlist README.md

--- a/.github/workflows/awesome-bot.yml
+++ b/.github/workflows/awesome-bot.yml
@@ -29,4 +29,4 @@ jobs:
       - name: "install awesome-bot"
         run: gem install awesome_bot
       - name: "linting: README.md"
-        run: awesome_bot --allow-redirect --allow-dupe --white-list quarto.org,https://github.com/quarto-dev,https://www.gnu.org/software/emacs/,https://rfortherestofus.com/ README.md
+        run: awesome_bot --allow-redirect --allow-dupe --white-list quarto.org,https://github.com/quarto-dev,https://www.gnu.org/software/emacs/,https://rfortherestofus.com/,https://drmowinckels.io/ README.md

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Contributions of any kind are welcome, just follow the [guidelines](.github/CONT
 - [Tutorial: Personal Website using Jupyter Notebook and Quarto](https://adtarie.net/posts/007-quarto-python-tutorial/) - A Python-oriented step-by-step tutorial on how to create a website using Quarto.
 - [Tutorial: Publish a Quarto website with Netlify](https://jadeyryan.com/blog/2023-11-19_publish-quarto-website/) - A comprehensive blog post walking through how to create a Quarto website, connect it to GitHub, deploy & publish it with Netlify by Jadey Ryan.
 - [Workshop: Parameterized Reports with Quarto](https://jadeyryan.quarto.pub/rladies-dc-quarto-params/) - A 2-hour code-along workshop to learn parameterized reporting with `quarto` and `purrr` to generate multiple format outputs (materials: <https://github.com/jadeynryan/parameterized-quarto-workshop>).
-- [Tutorials: Quarto Visual Editor and RStudio](https://youtube.com/playlist?list=PLEzw67WWDg80-fT1hq2IZf7D62tRmKy8f&si=ECVfFIH1bg6_JfjS) - A YouTube playlist of short video tutorials for beginners to work with Quarto Visual Editor and RStudio by Andy Field.
-- [Quarto for amsmath LaTeX users](https://nmfs-opensci.github.io/quarto-amsmath) - Notes focused on addressing issues related to using amsmath LaTeX for numbered equations and fancy math in Quarto books, specifically for HTML and PDF rendering.
+- [Tutorials: Quarto Visual Editor and RStudio](https://www.youtube.com/playlist?list=PLEzw67WWDg80-fT1hq2IZf7D62tRmKy8f&si=ECVfFIH1bg6_JfjS) - A YouTube playlist of short video tutorials for beginners to work with Quarto Visual Editor and RStudio by Andy Field.
+- [Quarto for amsmath LaTeX users](https://nmfs-opensci.github.io/quarto-amsmath/) - Notes focused on addressing issues related to using amsmath LaTeX for numbered equations and fancy math in Quarto books, specifically for HTML and PDF rendering.
 - [Tutorial: A step-by-step guide to parameterized reporting in R using Quarto](https://rfortherestofus.com/2024/06/parameterized-reporting-quarto) - A walkthrough of how to use parameterized reporting with Quarto with videos.
 - [Slidecrafting](https://slidecrafting-book.com/) - A book about slidecrafting, the art of putting together slides that are functional and aesthetically pleasing by Emil Hvitfeldt.
 - [Workshop: Branded Websites, Presentations, Dashboards, and PDFs with Quarto](https://posit-conf-2025.github.io/quarto-brand/) - posit::conf(2025) workshop materials on creating branded Quarto outputs, led by Isabella Velásquez and Sara Altman (materials available under CC BY-SA 4.0 license).
@@ -86,12 +86,12 @@ Contributions of any kind are welcome, just follow the [guidelines](.github/CONT
 
 - [We don't talk about Quarto](https://www.apreshill.com/blog/2022-04-we-dont-talk-about-quarto/) - A blog post introducing Quarto publishing software by Alison Presmanes Hill.
 - [Quarto tip a day](https://mine-cetinkaya-rundel.github.io/quarto-tip-a-day/) - A website made with Quarto highlighting a tip for Quarto every day as a blog post.
-- [Announcing Quarto, a new scientific and technical publishing system](https://posit.co/blog/announcing-quarto-a-new-scientific-and-technical-publishing-system/) - Blog post by J.J. Allaire announcing the launch of Quarto, a new open-source scientific and technical publishing system.
+- [Announcing Quarto, a new scientific and technical publishing system](https://posit.co/blog/announcing-quarto-a-new-scientific-and-technical-publishing-system) - Blog post by J.J. Allaire announcing the launch of Quarto, a new open-source scientific and technical publishing system.
 - [Interactive Molecular Content](https://www.valencekjell.com/posts/2022-08-13-interactive/) - A blog post showing how to embed interactive content (_i.e._, molecular visualisation) in webpages with Quarto using Bokeh, 3DMol.js and NGL.
 - [Slidecraft 101: Colors and Fonts](https://emilhvitfeldt.com/post/slidecraft-colors-fonts/) - A blog post about "The art of putting together slides that are functional and aesthetically pleasing" using Quarto presentation format by Emil Hvitfeldt.
 - [Making Slides in Quarto with Reveal.js](https://meghan.rbind.io/blog/2022-07-12-making-slides-in-quarto-with-revealjs/) - A blog post about making slides in Quarto with Reveal.js and how to use emojis or customise the slides by Meghan Hall.
 - [A beginner's guide to using Observable JavaScript, R, and Python with Quarto](https://www.infoworld.com/article/2336848/a-beginners-guide-to-using-observable-javascript-r-and-python-with-quarto.html) - This article shows you how to set up a Quarto document to use Observable JavaScript, including how to pass data from R or Python to an Observable code chunk.
-- [Six Productivity Hacks for Quarto](https://posit.co/blog/6-productivity-hacks-for-quarto/) - A blog post showing six tips from re-using content across documents, the insertion of Pandoc divs and spans to continuous deployment with GitHub Actions.
+- [Six Productivity Hacks for Quarto](https://posit.co/blog/6-productivity-hacks-for-quarto) - A blog post showing six tips from re-using content across documents, the insertion of Pandoc divs and spans to continuous deployment with GitHub Actions.
 - [Use R to Generate a Quarto Blogpost](https://themockup.blog/posts/2022-11-08-use-r-to-generate-a-quarto-blogpost/) - A blog post about using R to generate a Quarto blog post by Tom Mock.
 - [Adding Subscriptions to a Quarto Site](https://forbo7.github.io/forblog/posts/7_blog_subscriptions.html) - A blog post about how to add a subscription form to your Quarto blog.
 - [I'm an R user: Quarto or R Markdown?](https://www.jumpingrivers.com/blog/quarto-rmarkdown-comparison/) - A blog post comparing Quarto and R Markdown from an R user perspective by [Jumping Rivers](https://www.jumpingrivers.com/).
@@ -107,20 +107,20 @@ Contributions of any kind are welcome, just follow the [guidelines](.github/CONT
 ## Talks and videos
 
 - [Reproducible authoring with Quarto](https://www.youtube.com/watch?v=6p4vOKS6Xls) - 2022 Toronto Workshop on Reproducibility with Mine Çetinkaya-Rundel (slides: <https://mine-cetinkaya-rundel.github.io/2022-repro-toronto/>).
-- [Reproducible Publications with Julia and Quarto](https://www.youtube.com/watch?v=Y1uKNO32H_I) - JuliaCon 2022 with J.J. Allaire (slides: <https://jjallaire.github.io/quarto-juliacon-2022>).
+- [Reproducible Publications with Julia and Quarto](https://www.youtube.com/watch?v=Y1uKNO32H_I) - JuliaCon 2022 with J.J. Allaire (slides: <https://jjallaire.github.io/quarto-juliacon-2022/>).
 - [A Conversation about Quarto](https://www.youtube.com/watch?v=azVAl343CIU) - [Openscapes](https://openscapes.org/) Community Talk: Hello Quarto!
 - [Workshop: Welcome to Quarto 2-hour Workshop](https://www.youtube.com/watch?v=yvi5uXQMvu4) - RStudio Meetup: Welcome to Quarto 2-hour Workshop by Tom Mock (slides: <https://jthomasmock.github.io/quarto-2hr-webinar/>).
-- [Quarto for the Curious](https://posit.co/resources/videos/quarto-for-rmarkdown-users/) - A Quarto overview given by Tom Mock at RStudio::conf(2022) (materials: <https://thomasmock.quarto.pub/quarto-curious/>).
-- [Hello Quarto: Share • Collaborate • Teach • Reimagine](https://posit.co/resources/videos/hello-quarto-share-collaborate-teach-reimagine/) - Keynote by Mine Çetinkaya-Rundel & Julia Stewart Lowndes highlighting how they leverage Quarto in open-science at RStudio::conf(2022) (materials: <https://github.com/mine-cetinkaya-rundel/hello-quarto>).
-- [Websites & Books & Blogs, oh my! Creating Rich Content with Quarto](https://posit.co/resources/videos/websites-books-blogs-oh-my-creating-rich-content-with-quarto/) - Talk by Devin Pastoor at RStudio::conf(2022) showing some of the formats available in Quarto and how it is easy to focus on contents while Quarto takes care of the rest.
+- [Quarto for the Curious](https://posit.co/resources/videos/quarto-for-rmarkdown-users) - A Quarto overview given by Tom Mock at RStudio::conf(2022) (materials: <https://thomasmock.quarto.pub/quarto-curious/>).
+- [Hello Quarto: Share • Collaborate • Teach • Reimagine](https://posit.co/resources/videos/hello-quarto-share-collaborate-teach-reimagine) - Keynote by Mine Çetinkaya-Rundel & Julia Stewart Lowndes highlighting how they leverage Quarto in open-science at RStudio::conf(2022) (materials: <https://github.com/mine-cetinkaya-rundel/hello-quarto>).
+- [Websites & Books & Blogs, oh my! Creating Rich Content with Quarto](https://posit.co/resources/videos/websites-books-blogs-oh-my-creating-rich-content-with-quarto) - Talk by Devin Pastoor at RStudio::conf(2022) showing some of the formats available in Quarto and how it is easy to focus on contents while Quarto takes care of the rest.
 - [Literate Programming With Jupyter Notebooks and Quarto](https://www.youtube.com/watch?v=C8kDPmb_IKU) - Talk by Hamel Husain at RStudio::conf(2022) describing the integration between [Nbdev](https://github.com/AnswerDotAI/nbdev) and Quarto (materials: <https://github.com/fastai/nbdev-demo>).
-- [These are a few of my favorite things](https://posit.co/resources/videos/these-are-a-few-of-my-favorite-things-about-quarto-presentations/) - Talk by Tracy Teal at RStudio::conf(2022) highlighting some of the features of Quarto presentation, such as multiple columns, speaker notes and mode, transitions, _etc._
+- [These are a few of my favorite things](https://posit.co/resources/videos/these-are-a-few-of-my-favorite-things-about-quarto-presentations) - Talk by Tracy Teal at RStudio::conf(2022) highlighting some of the features of Quarto presentation, such as multiple columns, speaker notes and mode, transitions, _etc._
 - [Building a Blog with Quarto](https://www.youtube.com/watch?v=CVcvXfRyfE0) - RStudio Meetup: Building a Blog with Quarto by Isabella Velásquez (materials: <https://ivelasq.quarto.pub/building-a-blog-with-quarto/>).
 - [Beautiful Reports and Presentations with Quarto](https://www.youtube.com/watch?v=hbf7Ai3jnxY) - RStudio Meetup: Beautiful Reports and Presentations with Quarto by Tom Mock (materials: <https://github.com/jthomasmock/quarto-reporting>).
 - [Introduction to Quarto](https://www.youtube.com/watch?v=y6_xMIBKuP4) - R-Ladies St. Louis: Introduction to Quarto by Isabella Velásquez (materials: <https://github.com/ivelasq/2022-10-27_intro-to-quarto>).
 - [Quarto YouTube Playlist](https://www.youtube.com/playlist?list=PLDqZV53PcnYxnBYuEdSBxnOwdKLGaoKGg) - A YouTube playlist of videos about Quarto and Pandoc by Eli Holmes.
 - [Create your Data Science Portfolio with Quarto](https://www.youtube.com/watch?v=xtSFXtDf4cM) - In this video by Deepsha Menghani, learn how you can easily create a Data Science Portfolio website and deploy it instantly with the help of Quarto (materials: <https://deepshamenghani.quarto.pub/portfolio-with-quarto-workshop/#/title-slide>).
-- [A Coffee with Quarto and Neovim](https://youtube.com/playlist?list=PLabWm-zCaD1axcMGvf7wFxJz8FZmyHSJ7) - A YouTube playlist showing you how to use Quarto in Neovim by [Jannik Buhr](https://jmbuhr.de/).
+- [A Coffee with Quarto and Neovim](https://www.youtube.com/playlist?list=PLabWm-zCaD1axcMGvf7wFxJz8FZmyHSJ7) - A YouTube playlist showing you how to use Quarto in Neovim by [Jannik Buhr](https://jmbuhr.de/).
 - [How to style your Quarto blog without knowing a lot of HTML/CSS?](https://www.youtube.com/watch?v=ErRX8plZpQE) - This is a video tutorial on styling your Quarto blog even if you lack a strong foundation of HTML/CSS by Albert Rapp.
 - [Quarto for Academics](https://www.youtube.com/watch?v=EbAAmrB0luA) - This video highlights some of Quarto's features that are especially useful for academics, as educators and as researchers by Mine Çetinkaya-Rundel.
 - [Quarto Dashboards](https://www.youtube.com/watch?v=_VGJIPRGTy4) - This video highlights the new dashboard feature arriving in Quarto 1.4 by Charles Teague.
@@ -138,7 +138,7 @@ Contributions of any kind are welcome, just follow the [guidelines](.github/CONT
 - [Vim](https://github.com/quarto-dev/quarto-vim) - Plugin for [Vim](https://www.vim.org/) to work with Quarto.
 - [Visual Studio Code/Positron](https://github.com/quarto-dev/quarto) - Extension for [Visual Studio Code/Positron](https://code.visualstudio.com/) to work with Quarto.
 - [Scrivener](https://forum.literatureandlatte.com/t/scrivener-quarto-a-technical-academic-publishing-workflow/129769) - Quarto support for [Scrivener](https://www.literatureandlatte.com/) via Scrivener Template.
-- [RStudio](https://posit.co/products/open-source/rstudio/) - IDE by [Posit PBC](https://posit.co/) that natively supports Quarto.
+- [RStudio](https://posit.co/products/open-source/rstudio) - IDE by [Posit PBC](https://posit.co/) that natively supports Quarto.
 - [Positron](https://positron.posit.co/) - A next-generation extensible, polyglot data science IDE built by Posit PBC (support via [the Visual Studio Code extension for Quarto](https://github.com/quarto-dev/quarto)).
 
 ## Libraries/Packages/Scripts
@@ -218,7 +218,6 @@ Contributions of any kind are welcome, just follow the [guidelines](.github/CONT
 ### Websites formats
 
 - [quarto.org](https://github.com/quarto-dev/quarto-web) - The Quarto documentation website.
-- [rlille.fr](https://github.com/RLille/rlille.fr) - The R Lille (R User Group) website using Quarto.
 - [R-Manuals](https://github.com/rstudio/r-manuals) - R Manuals rewritten with Quarto.
 - [Quarto tip a day](https://github.com/mine-cetinkaya-rundel/quarto-tip-a-day) - Website/blog highlighting a tip for Quarto every day.
 - [Documentation website from Jupyter Notebook](https://github.com/aeturrell/skimpy) - Quarto used to generate a website from a Jupyter notebook containing Python module documentation.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 The most up to date curated list of [Quarto®](https://quarto.org) docs, talks, tools, examples & articles the internet has to offer.
 
-[Quarto®](https://quarto.org) is an open-source scientific and technical publishing system built on [Pandoc](<[Pandoc](https://pandoc.org/)>).
+[Quarto®](https://quarto.org) is an open-source scientific and technical publishing system built on [Pandoc](https://pandoc.org/).
 
 </div>
 
@@ -65,11 +65,11 @@ Contributions of any kind are welcome, just follow the [guidelines](.github/CONT
 - [Workshop: Quarto, a library to run them all?](https://warwickcim.github.io/quarto-workshop/slides/slides.html) - Workshop at [RSECon'22](https://rsecon2022.society-rse.org/), led by Carlos Cámara, James Tripp and Cagatay Turkay (materials: <https://github.com/WarwickCIM/quarto-workshop>).
 - [Tutorial: Creating your personal website using Quarto](https://ucsb-meds.github.io/creating-quarto-websites/) - A step-by-step guide for setting up a personal website using Quarto by Samantha Csik.
 - [Tutorial: Customizing Quarto Websites - Make your website stand out using SASS & CSS](https://ucsb-meds.github.io/customizing-quarto-websites/) - Slides by Samantha Csik about using SASS and CSS to customise HTML Quarto websites (materials: <https://github.com/UCSB-MEDS/customizing-quarto-websites>).
-- [Workshop: Quartaki — 6 hour introduction to Quarto](https://drmowinckels.github.io/quartaki/) - Using R and RStudio by [Athanasia Mo Mowinckel](https://github.com/drmowinckels) covering basic markdown, html reports, citation & cross-refs, pdf and journal templates and Reveal.js presentations.
+- [Workshop: Quartaki — 6 hour introduction to Quarto](https://drmowinckels.io/quartaki/) - Using R and RStudio by [Athanasia Mo Mowinckel](https://github.com/drmowinckels) covering basic markdown, html reports, citation & cross-refs, pdf and journal templates and Reveal.js presentations.
 - [Workshop: Mi primer blog con Quarto](https://perezp44.github.io/taller.primer.blog/) - A workshop in Spanish by Pedro J. Pérez to create a blog with Quarto (materials: <https://github.com/perezp44/taller.primer.blog>).
 - [Tutorial: Creating Quarto Journal Article Templates](https://christophertkenny.com/posts/2023-07-01-creating-quarto-journal-articles/) - An in-depth blog post detailing the process for converting journal LaTeX templates into Quarto templates.
 - [Tutorial: Personal Website using Jupyter Notebook and Quarto](https://adtarie.net/posts/007-quarto-python-tutorial/) - A Python-oriented step-by-step tutorial on how to create a website using Quarto.
-- [Tutorial: Publish a Quarto website with Netlify](https://jadeyryan.com/blog/publish-quarto-website/) - A comprehensive blog post walking through how to create a Quarto website, connect it to GitHub, deploy & publish it with Netlify by Jadey Ryan.
+- [Tutorial: Publish a Quarto website with Netlify](https://jadeyryan.com/blog/2023-11-19_publish-quarto-website/) - A comprehensive blog post walking through how to create a Quarto website, connect it to GitHub, deploy & publish it with Netlify by Jadey Ryan.
 - [Workshop: Parameterized Reports with Quarto](https://jadeyryan.quarto.pub/rladies-dc-quarto-params/) - A 2-hour code-along workshop to learn parameterized reporting with `quarto` and `purrr` to generate multiple format outputs (materials: <https://github.com/jadeynryan/parameterized-quarto-workshop>).
 - [Tutorials: Quarto Visual Editor and RStudio](https://youtube.com/playlist?list=PLEzw67WWDg80-fT1hq2IZf7D62tRmKy8f&si=ECVfFIH1bg6_JfjS) - A YouTube playlist of short video tutorials for beginners to work with Quarto Visual Editor and RStudio by Andy Field.
 - [Quarto for amsmath LaTeX users](https://nmfs-opensci.github.io/quarto-amsmath) - Notes focused on addressing issues related to using amsmath LaTeX for numbered equations and fancy math in Quarto books, specifically for HTML and PDF rendering.
@@ -77,7 +77,7 @@ Contributions of any kind are welcome, just follow the [guidelines](.github/CONT
 - [Slidecrafting](https://slidecrafting-book.com/) - A book about slidecrafting, the art of putting together slides that are functional and aesthetically pleasing by Emil Hvitfeldt.
 - [Workshop: Branded Websites, Presentations, Dashboards, and PDFs with Quarto](https://posit-conf-2025.github.io/quarto-brand/) - posit::conf(2025) workshop materials on creating branded Quarto outputs, led by Isabella Velásquez and Sara Altman (materials available under CC BY-SA 4.0 license).
 - [Workshop: Extending Quarto](https://posit-conf-2025.github.io/quarto-extend/) - posit::conf(2025) workshop materials on developing custom extensions, formats, templates, and filters, led by Mine Çetinkaya-Rundel and Charlotte Wickham (materials available under CC BY-SA 4.0 license).
-- [Tutorial: Using GitHub Codespaces to teach with Quarto](https://quarto.org/docs/blog/posts/2025-05-19-quarto-codespaces/) - Learn the basics of GitHub Codespaces and how to use them to make it easier to teach using Quarto by Mickaël Canouil.
+- [Tutorial: Using GitHub Codespaces to teach with Quarto](https://opensource.posit.co/blog/2025-05-19_quarto-codespaces/) - Learn the basics of GitHub Codespaces and how to use them to make it easier to teach using Quarto by Mickaël Canouil.
 - [Tutorial: How to Get a Blog Up from Scratch in 1 Day Using Quarto and Netlify](https://eliottkalfon.com/posts/quarto-blog-tutorial/) - A comprehensive step-by-step guide to setting up a Quarto blog with Netlify deployment in a single day by Eliott Kalfon.
 - [Tutorial: Writing a book with Quarto](https://blog.stephenturner.us/p/quarto-books) - A detailed walkthrough of transforming an old course website made from RMarkdown documents into a polished e-book using Quarto by Stephen Turner.
 - [Workshop: Beginner-friendly tutorial on using Quarto for sharing research](https://pythonhealthdatascience.github.io/quarto-tutorial/) - A step-by-step guide on building a Quarto website to share and organise research, targeted at beginners (introducing GitHub, Quarto, and Markdown, with no prior experience needed).
@@ -86,20 +86,19 @@ Contributions of any kind are welcome, just follow the [guidelines](.github/CONT
 
 - [We don't talk about Quarto](https://www.apreshill.com/blog/2022-04-we-dont-talk-about-quarto/) - A blog post introducing Quarto publishing software by Alison Presmanes Hill.
 - [Quarto tip a day](https://mine-cetinkaya-rundel.github.io/quarto-tip-a-day/) - A website made with Quarto highlighting a tip for Quarto every day as a blog post.
-- [Announcing Quarto, a new scientific and technical publishing system](https://www.rstudio.com/blog/announcing-quarto-a-new-scientific-and-technical-publishing-system/) - Blog post by J.J. Allaire announcing the launch of Quarto, a new open-source scientific and technical publishing system.
+- [Announcing Quarto, a new scientific and technical publishing system](https://posit.co/blog/announcing-quarto-a-new-scientific-and-technical-publishing-system/) - Blog post by J.J. Allaire announcing the launch of Quarto, a new open-source scientific and technical publishing system.
 - [Interactive Molecular Content](https://www.valencekjell.com/posts/2022-08-13-interactive/) - A blog post showing how to embed interactive content (_i.e._, molecular visualisation) in webpages with Quarto using Bokeh, 3DMol.js and NGL.
-- [Slidecraft 101: Colors and Fonts](https://www.emilhvitfeldt.com/post/slidecraft-colors-fonts/) - A blog post about "The art of putting together slides that are functional and aesthetically pleasing" using Quarto presentation format by Emil Hvitfeldt.
-- [Making Slides in Quarto with Reveal.js](https://meghan.rbind.io/blog/quarto-slides/) - A blog post about making slides in Quarto with Reveal.js and how to use emojis or customise the slides by Meghan Hall.
-- [A beginner's guide to using Observable JavaScript, R, and Python with Quarto](https://www.infoworld.com/article/3674789/a-beginners-guide-to-using-observable-javascript-r-and-python-with-quarto.html) - This article shows you how to set up a Quarto document to use Observable JavaScript, including how to pass data from R or Python to an Observable code chunk.
-- [Six Productivity Hacks for Quarto](https://www.rstudio.com/blog/6-productivity-hacks-for-quarto/) - A blog post showing six tips from re-using content across documents, the insertion of Pandoc divs and spans to continuous deployment with GitHub Actions.
-- [How to add some personality to your Quarto Blog](https://www.ddanieltan.com/posts/blogtips/) - A blog post sharing some of the added features and tweaks users can make on top of the standard blog templates to inject some personality into their blog.
+- [Slidecraft 101: Colors and Fonts](https://emilhvitfeldt.com/post/slidecraft-colors-fonts/) - A blog post about "The art of putting together slides that are functional and aesthetically pleasing" using Quarto presentation format by Emil Hvitfeldt.
+- [Making Slides in Quarto with Reveal.js](https://meghan.rbind.io/blog/2022-07-12-making-slides-in-quarto-with-revealjs/) - A blog post about making slides in Quarto with Reveal.js and how to use emojis or customise the slides by Meghan Hall.
+- [A beginner's guide to using Observable JavaScript, R, and Python with Quarto](https://www.infoworld.com/article/2336848/a-beginners-guide-to-using-observable-javascript-r-and-python-with-quarto.html) - This article shows you how to set up a Quarto document to use Observable JavaScript, including how to pass data from R or Python to an Observable code chunk.
+- [Six Productivity Hacks for Quarto](https://posit.co/blog/6-productivity-hacks-for-quarto/) - A blog post showing six tips from re-using content across documents, the insertion of Pandoc divs and spans to continuous deployment with GitHub Actions.
 - [Use R to Generate a Quarto Blogpost](https://themockup.blog/posts/2022-11-08-use-r-to-generate-a-quarto-blogpost/) - A blog post about using R to generate a Quarto blog post by Tom Mock.
 - [Adding Subscriptions to a Quarto Site](https://forbo7.github.io/forblog/posts/7_blog_subscriptions.html) - A blog post about how to add a subscription form to your Quarto blog.
 - [I'm an R user: Quarto or R Markdown?](https://www.jumpingrivers.com/blog/quarto-rmarkdown-comparison/) - A blog post comparing Quarto and R Markdown from an R user perspective by [Jumping Rivers](https://www.jumpingrivers.com/).
 - [Quarto for the Python User](https://www.jumpingrivers.com/blog/quarto-for-python-users/) - A blog post introducing Quarto to Python users for creating reports.
 - [How to publish your Quarto document/book/website as a Docker container?](https://mickael.canouil.fr/posts/2023-05-07-quarto-docker/) - A blog post describing how to publish your Quarto document/book/website as a Docker container by Mickaël Canouil.
 - [Making Pretty PDFs with Quarto](https://nrennie.rbind.io/blog/pdf-quarto/making-pretty-pdf-quarto/) - A blog post showing how to customise the styling of PDF documents, and save the styling into a Quarto extension to make it easier to reuse and share.
-- [How to self-publish a technical book on Leanpub and Amazon using Quarto](https://www.brodrigues.co/blog/2023-06-29-book_quarto/) - This blog post explains which settings to use to compile an Epub for Leanpub and a print-ready PDF for Amazon's self-publishing service (KDP).
+- [How to self-publish a technical book on Leanpub and Amazon using Quarto](https://brodrigues.co/blog/2023-06-29-book_quarto/) - This blog post explains which settings to use to compile an Epub for Leanpub and a print-ready PDF for Amazon's self-publishing service (KDP).
 - [Hello Quarto: Porting my Website from Hugo Apéro](https://silviacanelon.com/blog/2023-09-29-hello-quarto/) - A blog post detailing a user's experience of porting a blogdown Hugo Apéro site to Quarto, with content including design ideas, CSS tips, HTML partials, setting up redirects, and others.
 - [Seven Tips for Creating Quarto Reveal.js Presentations](https://remlapmot.github.io/post/2025/quarto-revealjs-tips/) - A blog post showing a few tips on how to customise Reveal.js slides with R/knitr, HTML/CSS, and Quarto native options.
 - [Creating effectively multi-engine Quarto documents using Quarto's embed shortcode](https://remlapmot.github.io/post/2025/multi-engine-quarto/) - A blog post describing how to use the embed shortcode to show code and execute its output from different languages/engines in the same document.
@@ -109,14 +108,13 @@ Contributions of any kind are welcome, just follow the [guidelines](.github/CONT
 
 - [Reproducible authoring with Quarto](https://www.youtube.com/watch?v=6p4vOKS6Xls) - 2022 Toronto Workshop on Reproducibility with Mine Çetinkaya-Rundel (slides: <https://mine-cetinkaya-rundel.github.io/2022-repro-toronto/>).
 - [Reproducible Publications with Julia and Quarto](https://www.youtube.com/watch?v=Y1uKNO32H_I) - JuliaCon 2022 with J.J. Allaire (slides: <https://jjallaire.github.io/quarto-juliacon-2022>).
-- [A Conversation about Quarto](https://www.youtube.com/watch?v=azVAl343CIU) - [Openscapes](https://www.openscapes.org/) Community Talk: Hello Quarto!
-- [Tutorial: How to style your Quarto blog without knowing a lot of HTML/CSS](https://www.youtube.com/watch?v=ErRX8plZpQE) - This is a video tutorial on styling your Quarto blog even if you lack a strong foundation of HTML/CSS.
+- [A Conversation about Quarto](https://www.youtube.com/watch?v=azVAl343CIU) - [Openscapes](https://openscapes.org/) Community Talk: Hello Quarto!
 - [Workshop: Welcome to Quarto 2-hour Workshop](https://www.youtube.com/watch?v=yvi5uXQMvu4) - RStudio Meetup: Welcome to Quarto 2-hour Workshop by Tom Mock (slides: <https://jthomasmock.github.io/quarto-2hr-webinar/>).
-- [Quarto for the Curious](https://www.rstudio.com/conference/2022/talks/quarto-for-rmarkdown-users/) - A Quarto overview given by Tom Mock at RStudio::conf(2022) (materials: <https://thomasmock.quarto.pub/quarto-curious/>).
-- [Hello Quarto: Share • Collaborate • Teach • Reimagine](https://www.rstudio.com/conference/2022/keynotes/collaborate-with-quarto/) - Keynote by Mine Çetinkaya-Rundel & Julia Stewart Lowndes highlighting how they leverage Quarto in open-science at RStudio::conf(2022) (materials: <https://github.com/mine-cetinkaya-rundel/hello-quarto>).
-- [Websites & Books & Blogs, oh my! Creating Rich Content with Quarto](https://www.rstudio.com/conference/2022/talks/sessions/quarto-deep-dive/websites-books-blogs-quarto/) - Talk by Devin Pastoor at RStudio::conf(2022) showing some of the formats available in Quarto and how it is easy to focus on contents while Quarto takes care of the rest.
-- [Literate Programming With Jupyter Notebooks and Quarto](https://www.rstudio.com/conference/2022/talks/literate-programming-quarto/) - Talk by Hamel Husain at RStudio::conf(2022) describing the integration between [Nbdev](https://github.com/fastai/nbdev) and Quarto (materials: <https://github.com/fastai/nbdev-demo>).
-- [These are a few of my favorite things](https://www.rstudio.com/conference/2022/talks/my-favorite-things-quarto-presentations/) - Talk by Tracy Teal at RStudio::conf(2022) highlighting some of the features of Quarto presentation, such as multiple columns, speaker notes and mode, transitions, _etc._
+- [Quarto for the Curious](https://posit.co/resources/videos/quarto-for-rmarkdown-users/) - A Quarto overview given by Tom Mock at RStudio::conf(2022) (materials: <https://thomasmock.quarto.pub/quarto-curious/>).
+- [Hello Quarto: Share • Collaborate • Teach • Reimagine](https://posit.co/resources/videos/hello-quarto-share-collaborate-teach-reimagine/) - Keynote by Mine Çetinkaya-Rundel & Julia Stewart Lowndes highlighting how they leverage Quarto in open-science at RStudio::conf(2022) (materials: <https://github.com/mine-cetinkaya-rundel/hello-quarto>).
+- [Websites & Books & Blogs, oh my! Creating Rich Content with Quarto](https://posit.co/resources/videos/websites-books-blogs-oh-my-creating-rich-content-with-quarto/) - Talk by Devin Pastoor at RStudio::conf(2022) showing some of the formats available in Quarto and how it is easy to focus on contents while Quarto takes care of the rest.
+- [Literate Programming With Jupyter Notebooks and Quarto](https://www.youtube.com/watch?v=C8kDPmb_IKU) - Talk by Hamel Husain at RStudio::conf(2022) describing the integration between [Nbdev](https://github.com/AnswerDotAI/nbdev) and Quarto (materials: <https://github.com/fastai/nbdev-demo>).
+- [These are a few of my favorite things](https://posit.co/resources/videos/these-are-a-few-of-my-favorite-things-about-quarto-presentations/) - Talk by Tracy Teal at RStudio::conf(2022) highlighting some of the features of Quarto presentation, such as multiple columns, speaker notes and mode, transitions, _etc._
 - [Building a Blog with Quarto](https://www.youtube.com/watch?v=CVcvXfRyfE0) - RStudio Meetup: Building a Blog with Quarto by Isabella Velásquez (materials: <https://ivelasq.quarto.pub/building-a-blog-with-quarto/>).
 - [Beautiful Reports and Presentations with Quarto](https://www.youtube.com/watch?v=hbf7Ai3jnxY) - RStudio Meetup: Beautiful Reports and Presentations with Quarto by Tom Mock (materials: <https://github.com/jthomasmock/quarto-reporting>).
 - [Introduction to Quarto](https://www.youtube.com/watch?v=y6_xMIBKuP4) - R-Ladies St. Louis: Introduction to Quarto by Isabella Velásquez (materials: <https://github.com/ivelasq/2022-10-27_intro-to-quarto>).
@@ -127,10 +125,10 @@ Contributions of any kind are welcome, just follow the [guidelines](.github/CONT
 - [Quarto for Academics](https://www.youtube.com/watch?v=EbAAmrB0luA) - This video highlights some of Quarto's features that are especially useful for academics, as educators and as researchers by Mine Çetinkaya-Rundel.
 - [Quarto Dashboards](https://www.youtube.com/watch?v=_VGJIPRGTy4) - This video highlights the new dashboard feature arriving in Quarto 1.4 by Charles Teague.
 - [Parameterized Quarto reports improve understanding of soil health](https://www.youtube.com/watch?v=lbE5uOqfT70) - posit::conf(2023) talk by Jadey Ryan provides an example workflow of creating parameterized reports with HTML and MS Word outputs (materials: <https://jadeynryan.github.io/2023_posit-parameterized-quarto/>).
-- [posit::conf(2024) Quarto talks](https://quarto.org/docs/blog/posts/2024-11-06-conf-talks/) - Videos of talks from posit::conf(2024) are posted, compiled playlist of Quarto talks available on YouTube.
-- [posit::conf(2024) Quarto workshop materials](https://quarto.org/docs/blog/posts/2024-10-15-conf-workshops-materials/index.html) - Materials from three Quarto workshops at posit::conf(2024), including "Hello Quarto", "Quarto Websites" and "Beautiful documents with Quarto", all available to learn and teach from.
-- [posit::conf(2025) Quarto talks](https://quarto.org/docs/blog/posts/2025-11-24-conf-talk-videos/) - Videos of talks from posit::conf(2025) showcasing Quarto, including talks on using Quarto for reports, election night reporting, business collaboration, and more.
-- [posit::conf(2025) Quarto workshop materials](https://quarto.org/docs/blog/posts/2025-10-27-conf-workshops-materials/) - Materials from Quarto workshops at posit::conf(2025), including "Branded Websites, Presentations, Dashboards, and PDFs with Quarto" and "Extending Quarto", all available to learn and teach from.
+- [posit::conf(2024) Quarto talks](https://opensource.posit.co/blog/2024-11-06_conf-talks/) - Videos of talks from posit::conf(2024) are posted, compiled playlist of Quarto talks available on YouTube.
+- [posit::conf(2024) Quarto workshop materials](https://opensource.posit.co/blog/2024-10-15_conf-workshops-materials/) - Materials from three Quarto workshops at posit::conf(2024), including "Hello Quarto", "Quarto Websites" and "Beautiful documents with Quarto", all available to learn and teach from.
+- [posit::conf(2025) Quarto talks](https://opensource.posit.co/blog/2025-11-24_conf-talk-videos/) - Videos of talks from posit::conf(2025) showcasing Quarto, including talks on using Quarto for reports, election night reporting, business collaboration, and more.
+- [posit::conf(2025) Quarto workshop materials](https://opensource.posit.co/blog/2025-10-27_conf-workshops-materials/) - Materials from Quarto workshops at posit::conf(2025), including "Branded Websites, Presentations, Dashboards, and PDFs with Quarto" and "Extending Quarto", all available to learn and teach from.
 
 ## Supported editors
 
@@ -159,7 +157,7 @@ Contributions of any kind are welcome, just follow the [guidelines](.github/CONT
 ### Julia
 
 - [Julia](https://github.com/quarto-dev/quarto-julia) - Interface package for [Julia](https://julialang.org/) to Quarto CLI.
-- [DocumenterQuarto](https://github.com/cadojo/DocumenterQuarto.jl) - A Julia package to generate documentation for Julia packages using Quarto and Documenter.
+- [DocumenterQuarto](https://github.com/jdc-pub/DocumenterQuarto.jl) - A Julia package to generate documentation for Julia packages using Quarto and Documenter.
 
 ### Python
 
@@ -226,7 +224,7 @@ Contributions of any kind are welcome, just follow the [guidelines](.github/CONT
 - [Documentation website from Jupyter Notebook](https://github.com/aeturrell/skimpy) - Quarto used to generate a website from a Jupyter notebook containing Python module documentation.
 - [Program Evaluation for Public Service (course)](https://github.com/andrewheiss/evalf22.classes.andrewheiss.com) - Website for a graduate-level course on program evaluation and causal inference using R, built with Quarto.
 - [Bioconductor Community Blog](https://github.com/Bioconductor/biocblog) - A Quarto Blog for the Bioconductor community.
-- [R for Social Scientists workshop](https://github.com/pittmethods/r4ss) - A Quarto website for a workshop which includes Quarto Reveal JS presentations embedded in it.
+- [R for Social Scientists workshop](https://github.com/SMaRTWorkshops/r4ss) - A Quarto website for a workshop which includes Quarto Reveal JS presentations embedded in it.
 - [AffCom Lab Website](https://github.com/jmgirard/affcomlab) - A research lab Quarto Blog/website using custom listing pages for people and publications.
 - [Quantum Jitter](https://github.com/cgoo4/quantumjitter) - A Quarto website / blog with a custom theme (adapted from flatly / darkly), day / night landing page and a novel 404 page.
 - [Andrew Heiss's website](https://github.com/andrewheiss/ath-quarto) - Website with custom EJS format, footer, 404 page, (S)CSS, and many more customisations.


### PR DESCRIPTION
An audit of all 229 links in the list surfaced link rot that CI could not catch, because `awesome-bot` ran with `--allow-redirect` and `--allow-dupe` and the README disables the `double-link` lint rule.

The entry for "How to add some personality to your Quarto Blog" is removed. The `ddanieltan.com` domain no longer belongs to the original author and now redirects to a gambling site.

The entry for "How to style your Quarto blog without knowing a lot of HTML/CSS" appeared twice under Talks and videos with the same YouTube URL. The version crediting Albert Rapp is kept and the other is removed.

The `rlille.fr` entry is removed. Its repository is archived, which the pull request template lists as grounds for exclusion.

Links are rewritten to their canonical destinations. The `rstudio.com` blog posts and rstudio::conf(2022) talk pages now live under `posit.co`, and the Literate Programming talk page resolves to YouTube. All five Quarto blog posts now serve from `opensource.posit.co`. `DocumenterQuarto.jl`, `nbdev`, and the R for Social Scientists workshop have moved to new GitHub organisations.

The Pandoc link in the header was nested inside itself, producing a broken URL, and is now a plain link.

`--allow-redirect` is dropped from the `awesome-bot` workflow. That flag is the reason the hijacked domain went unnoticed for so long: the link kept returning 200 through a redirect chain, so CI stayed green while the destination had become a gambling site. Redirects now fail the check, which surfaces link rot at review time instead of hiding it. This exposed eleven further URLs that were quietly redirecting on trailing slashes or a missing `www.`, all now pointing at their final destination.

Three redirects are white-listed because they cannot be fixed in the file: the `awesome.re` badge, the suggestion-issue link, which redirects to a login page only because CI is unauthenticated, and YouTube playlists, which redirect to a regional consent page. `drmowinckels.io` is also white-listed, since it returns 403 to GitHub Actions runners while serving 200 elsewhere, matching the existing `rfortherestofus.com` entry.

Verified with `awesome-lint` and `awesome_bot`, both clean under the stricter settings.
